### PR TITLE
Allow a user to specify the extraction directory

### DIFF
--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -88,6 +88,10 @@ def make_command_line_parser():
         type=bool_from_string,
         required=True)
     parser.add_argument(
+        '--extract_dir',
+        help='Set an explicit extraction output directory.  This is only ' +
+        'used if zip_safe is True.')
+    parser.add_argument(
         '--import_root',
         help='Path to add to sys.path, may be repeated to provide multiple roots.',
         action='append',
@@ -170,5 +174,6 @@ def main(argv):
         manifest_root=args.manifest_root,
         timestamp=args.timestamp,
         zip_safe=args.zip_safe,
+        extract_dir=args.extract_dir,
     )
     par.create()

--- a/compiler/python_archive.py
+++ b/compiler/python_archive.py
@@ -28,8 +28,8 @@ See also https://www.python.org/dev/peps/pep-0441/
 
 """
 
-from datetime import datetime
 import contextlib
+from datetime import datetime
 import errno
 import hashlib
 import io
@@ -284,7 +284,8 @@ class PythonArchive(object):
         """
 
         logging.debug('Storing Files...')
-        with contextlib.closing(zipfile.ZipFile(temp_parfile, 'w', self.compression)) as z:
+        with contextlib.closing(
+                zipfile.ZipFile(temp_parfile, 'w', self.compression)) as z:
             manifest_hash = hashlib.sha256()
             items = sorted(stored_resources.items())
             for relative_path, resource in items:
@@ -292,7 +293,7 @@ class PythonArchive(object):
                 resource.store(z)
                 _update_hash(manifest_hash, resource)
 
-            logging.info(
+            logging.debug(
                 "Hash calculated for manifest: %s", manifest_hash.hexdigest())
             hash_file = stored_resource.StoredContent(
                 "UNPAR_MANIFEST", self.timestamp_tuple,

--- a/compiler/python_archive.py
+++ b/compiler/python_archive.py
@@ -50,9 +50,9 @@ _boilerplate_template = """\
 # Boilerplate added by subpar/compiler/python_archive.py
 from %(runtime_package)s import support as _
 _.setup(
-    import_roots=%(import_roots)s,
+    import_roots=%(import_roots)r,
     zip_safe=%(zip_safe)s,
-    extract_dir="%(extract_dir)s"
+    extract_dir=%(extract_dir)r,
 )
 del _
 # End boilerplate
@@ -177,9 +177,9 @@ class PythonArchive(object):
         """
         boilerplate_contents = _boilerplate_template % {
             'runtime_package': _runtime_package,
-            'import_roots': str(import_roots),
+            'import_roots': import_roots,
             'zip_safe': self.zip_safe,
-            'extract_dir': self.extract_dir.replace('"', '\\"'),
+            'extract_dir': self.extract_dir,
         }
         return boilerplate_contents.encode('ascii').decode('ascii')
 

--- a/compiler/python_archive_test.py
+++ b/compiler/python_archive_test.py
@@ -51,6 +51,7 @@ class PythonArchiveTest(unittest.TestCase):
         self.date_time_tuple = (1980, 1, 1, 0, 0, 0)
         self.timestamp = 315532800
         self.zip_safe = True
+        self.extract_dir = None
 
     def _construct(self, manifest_filename=None):
         return python_archive.PythonArchive(
@@ -62,6 +63,7 @@ class PythonArchiveTest(unittest.TestCase):
             output_filename=self.output_filename,
             timestamp=self.timestamp,
             zip_safe=self.zip_safe,
+            extract_dir=self.extract_dir,
         )
 
     def test_create_manifest_not_found(self):

--- a/runtime/support.py
+++ b/runtime/support.py
@@ -113,7 +113,7 @@ def _extract_files(archive_path, extract_dir):
             except (OSError, IOError):
                 warnings.warn(
                     'Unable to extract to requested directory ' +
-                    '"%s", falling back to tmp dir' % extract_dir,
+                    '%r, falling back to tmp dir' % extract_dir,
                     UserWarning)
                 extract_dir = _make_temporary_extract_dir()
             else:
@@ -121,7 +121,7 @@ def _extract_files(archive_path, extract_dir):
         else:
             extract_dir = _make_temporary_extract_dir()
 
-        _log('# extracting %s to %s' % (archive_path, extract_dir))
+        _log('# extracting %r to %r' % (archive_path, extract_dir))
         zip_file.extractall(extract_dir)
 
     return extract_dir
@@ -381,8 +381,7 @@ def setup(import_roots, zip_safe, extract_dir=None):
             if extract_dir != original_extract_dir:
                 sys.exit("unable to extract to %r" % original_extract_dir)
 
-            sys.stderr.write("successfully unpacked par to %r" % extract_dir)
-            sys.stderr.write("\n")
+            sys.stderr.write("successfully unpacked par to %r\n" % extract_dir)
             sys.exit(0)
 
         # sys.path[0] is the name of the executing .par file.  Point

--- a/runtime/support.py
+++ b/runtime/support.py
@@ -334,17 +334,19 @@ def _initialize_import_path(import_roots, import_prefix):
     _log('# adding %s to sys.path' % full_roots)
 
 
-def setup(import_roots, zip_safe, extract_dir):
+def setup(import_roots, zip_safe, extract_dir=None):
     """Initialize subpar run-time support
 
     Args:
-      import_root (list): subdirs inside .par file to add to the
-                          module import path at runtime.
-      zip_safe (bool): If False, extract the .par file contents to a
-                       temporary directory, and import everything from
-                       that directory.
+      import_root (list[str]): subdirs inside .par file to add to the
+                               module import path at runtime.
 
-      extract_dir (str): TODO
+      zip_safe (bool): If False, extract the .par file contents to a
+                       directory, and import everything from that directory.
+
+      extract_dir (str): Optionally specify directory in which to extract the
+                         .par file. Ignored when zip_safe=True. Uses a tmp
+                         directory when not specified.
 
     Returns:
       True if setup was successful, else False
@@ -366,7 +368,7 @@ def setup(import_roots, zip_safe, extract_dir):
         extract_only = os.environ.get("UNPAR_EXTRACT_ONLY")
         if extract_only:
             if not extract_dir:
-                sys.exit("no extract_dir specified")
+                sys.exit("UNPAR_EXTRACT_ONLY specified without an extract_dir")
             else:
                 shutil.rmtree(extract_dir, ignore_errors=True)
 
@@ -377,9 +379,9 @@ def setup(import_roots, zip_safe, extract_dir):
 
         if extract_only:
             if extract_dir != original_extract_dir:
-                sys.exit("unable to extract to '%s'" % original_extract_dir)
+                sys.exit("unable to extract to %r" % original_extract_dir)
 
-            sys.stderr.write("successfully unpacked par to %s" % extract_dir)
+            sys.stderr.write("successfully unpacked par to %r" % extract_dir)
             sys.stderr.write("\n")
             sys.exit(0)
 

--- a/runtime/support_test.py
+++ b/runtime/support_test.py
@@ -101,7 +101,7 @@ class SupportTest(unittest.TestCase):
 
     def test__extract_files(self):
         # Extract zipfile
-        extract_path = support._extract_files(self.zipfile_name)
+        extract_path = support._extract_files(self.zipfile_name, None)
 
         # Check results
         self.assertTrue(os.path.isdir(extract_path))

--- a/subpar.bzl
+++ b/subpar.bzl
@@ -86,9 +86,11 @@ def _parfile_impl(ctx):
         ctx.attr.src.files_to_run.executable.path,
         "--zip_safe",
         str(zip_safe),
+        "--extract_dir",
+        ctx.attr.extract_dir,
     ]
     for import_root in import_roots:
-        args.extend(['--import_root', import_root])
+        args.extend(["--import_root", import_root])
     args.append(main_py_file.path)
 
     # Run compiler
@@ -138,6 +140,7 @@ parfile_attrs = {
     ),
     "compiler_args": attr.string_list(default = []),
     "zip_safe": attr.bool(default = True),
+    "extract_dir": attr.string(),
 }
 
 # Rule to create a parfile given a py_binary() as input
@@ -173,6 +176,10 @@ Args:
             extracted to a temporary directory on disk each time the
             par file executes.
 
+  extract_dir: A file path to extract the archive to if zip_safe is True. The default
+               behavior is to create a temporary directory (and clean it up!) for each
+               invocation.
+
 TODO(b/27502830): A directory foo.par.runfiles is also created. This
 is a bug, don't use or depend on it.
 """
@@ -206,6 +213,7 @@ def par_binary(name, **kwargs):
     compiler = kwargs.pop("compiler", None)
     compiler_args = kwargs.pop("compiler_args", [])
     zip_safe = kwargs.pop("zip_safe", True)
+    extract_dir = kwargs.pop("extract_dir", None)
     py_binary(name = name, **kwargs)
 
     main = kwargs.get("main", name + ".py")
@@ -225,6 +233,7 @@ def par_binary(name, **kwargs):
         testonly = testonly,
         visibility = visibility,
         zip_safe = zip_safe,
+        extract_dir = extract_dir,
         tags = tags,
     )
 
@@ -236,6 +245,7 @@ def par_test(name, **kwargs):
     """
     compiler = kwargs.pop("compiler", None)
     zip_safe = kwargs.pop("zip_safe", True)
+    extract_dir = kwargs.pop("extract_dir", None)
     py_test(name = name, **kwargs)
 
     main = kwargs.get("main", name + ".py")
@@ -254,5 +264,6 @@ def par_test(name, **kwargs):
         testonly = testonly,
         visibility = visibility,
         zip_safe = zip_safe,
+        extract_dir = extract_dir,
         tags = tags,
     )

--- a/test_dir_shadowing/test_dir_shadowing_main_PY2_filelist.txt
+++ b/test_dir_shadowing/test_dir_shadowing_main_PY2_filelist.txt
@@ -9,3 +9,4 @@ subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib_dat.txt
 subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main.py
 subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main_dat.txt
 subpar/test_dir_shadowing/test_dir_shadowing_main
+UNPAR_MANIFEST

--- a/test_dir_shadowing/test_dir_shadowing_main_PY3_filelist.txt
+++ b/test_dir_shadowing/test_dir_shadowing_main_PY3_filelist.txt
@@ -9,3 +9,4 @@ subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib_dat.txt
 subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main.py
 subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main_dat.txt
 subpar/test_dir_shadowing/test_dir_shadowing_main
+UNPAR_MANIFEST

--- a/tests/package_a/a_PY2_filelist.txt
+++ b/tests/package_a/a_PY2_filelist.txt
@@ -7,3 +7,4 @@ subpar/tests/package_a/__init__.py
 subpar/tests/package_a/a
 subpar/tests/package_a/a.py
 subpar/tests/package_a/a_dat.txt
+UNPAR_MANIFEST

--- a/tests/package_a/a_PY3_filelist.txt
+++ b/tests/package_a/a_PY3_filelist.txt
@@ -7,3 +7,4 @@ subpar/tests/package_a/__init__.py
 subpar/tests/package_a/a
 subpar/tests/package_a/a.py
 subpar/tests/package_a/a_dat.txt
+UNPAR_MANIFEST

--- a/tests/package_b/b_PY2_filelist.txt
+++ b/tests/package_b/b_PY2_filelist.txt
@@ -13,3 +13,4 @@ subpar/tests/package_b/__init__.py
 subpar/tests/package_b/b
 subpar/tests/package_b/b.py
 subpar/tests/package_b/b_dat.txt
+UNPAR_MANIFEST

--- a/tests/package_b/b_PY3_filelist.txt
+++ b/tests/package_b/b_PY3_filelist.txt
@@ -13,3 +13,4 @@ subpar/tests/package_b/__init__.py
 subpar/tests/package_b/b
 subpar/tests/package_b/b.py
 subpar/tests/package_b/b_dat.txt
+UNPAR_MANIFEST

--- a/tests/package_boilerplate/main_PY2_filelist.txt
+++ b/tests/package_boilerplate/main_PY2_filelist.txt
@@ -6,3 +6,4 @@ subpar/tests/__init__.py
 subpar/tests/package_boilerplate/__init__.py
 subpar/tests/package_boilerplate/main
 subpar/tests/package_boilerplate/main.py
+UNPAR_MANIFEST

--- a/tests/package_boilerplate/main_PY3_filelist.txt
+++ b/tests/package_boilerplate/main_PY3_filelist.txt
@@ -6,3 +6,4 @@ subpar/tests/__init__.py
 subpar/tests/package_boilerplate/__init__.py
 subpar/tests/package_boilerplate/main
 subpar/tests/package_boilerplate/main.py
+UNPAR_MANIFEST

--- a/tests/package_c/c_PY2_filelist.txt
+++ b/tests/package_c/c_PY2_filelist.txt
@@ -16,3 +16,4 @@ subpar/tests/package_b/b_dat.txt
 subpar/tests/package_c/__init__.py
 subpar/tests/package_c/c
 subpar/tests/package_c/c.py
+UNPAR_MANIFEST

--- a/tests/package_c/c_PY3_filelist.txt
+++ b/tests/package_c/c_PY3_filelist.txt
@@ -16,3 +16,4 @@ subpar/tests/package_b/b_dat.txt
 subpar/tests/package_c/__init__.py
 subpar/tests/package_c/c
 subpar/tests/package_c/c.py
+UNPAR_MANIFEST

--- a/tests/package_d/d_PY2_filelist.txt
+++ b/tests/package_d/d_PY2_filelist.txt
@@ -19,3 +19,4 @@ subpar/tests/package_c/c.py
 subpar/tests/package_d/__init__.py
 subpar/tests/package_d/d
 subpar/tests/package_d/d.py
+UNPAR_MANIFEST

--- a/tests/package_d/d_PY3_filelist.txt
+++ b/tests/package_d/d_PY3_filelist.txt
@@ -19,3 +19,4 @@ subpar/tests/package_c/c.py
 subpar/tests/package_d/__init__.py
 subpar/tests/package_d/d
 subpar/tests/package_d/d.py
+UNPAR_MANIFEST

--- a/tests/package_e/e_PY2_filelist.txt
+++ b/tests/package_e/e_PY2_filelist.txt
@@ -11,3 +11,4 @@ test_workspace/__init__.py
 test_workspace/data_file.txt
 test_workspace/package_external_lib/__init__.py
 test_workspace/package_external_lib/external_lib.py
+UNPAR_MANIFEST

--- a/tests/package_e/e_PY3_filelist.txt
+++ b/tests/package_e/e_PY3_filelist.txt
@@ -11,3 +11,4 @@ test_workspace/__init__.py
 test_workspace/data_file.txt
 test_workspace/package_external_lib/__init__.py
 test_workspace/package_external_lib/external_lib.py
+UNPAR_MANIFEST

--- a/tests/package_extract/extract_PY2_filelist.txt
+++ b/tests/package_extract/extract_PY2_filelist.txt
@@ -9,3 +9,4 @@ subpar/tests/package_extract/extract.py
 subpar/tests/package_extract/extract_helper.py
 subpar/tests/package_extract/extract_helper_package/__init__.py
 subpar/tests/package_extract/extract_helper_package/extract_dat.txt
+UNPAR_MANIFEST

--- a/tests/package_extract/extract_PY3_filelist.txt
+++ b/tests/package_extract/extract_PY3_filelist.txt
@@ -9,3 +9,4 @@ subpar/tests/package_extract/extract.py
 subpar/tests/package_extract/extract_helper.py
 subpar/tests/package_extract/extract_helper_package/__init__.py
 subpar/tests/package_extract/extract_helper_package/extract_dat.txt
+UNPAR_MANIFEST

--- a/tests/package_f/f_PY2_filelist.txt
+++ b/tests/package_f/f_PY2_filelist.txt
@@ -6,3 +6,4 @@ subpar/tests/__init__.py
 subpar/tests/package_f/__init__.py
 subpar/tests/package_f/f
 subpar/tests/package_f/f_PY2.py
+UNPAR_MANIFEST

--- a/tests/package_f/f_PY3_filelist.txt
+++ b/tests/package_f/f_PY3_filelist.txt
@@ -6,3 +6,4 @@ subpar/tests/__init__.py
 subpar/tests/package_f/__init__.py
 subpar/tests/package_f/f
 subpar/tests/package_f/f_PY3.py
+UNPAR_MANIFEST

--- a/tests/package_import_roots/import_roots_PY2_filelist.txt
+++ b/tests/package_import_roots/import_roots_PY2_filelist.txt
@@ -6,3 +6,4 @@ subpar/tests/__init__.py
 subpar/tests/package_import_roots/__init__.py
 subpar/tests/package_import_roots/import_roots
 subpar/tests/package_import_roots/import_roots.py
+UNPAR_MANIFEST

--- a/tests/package_import_roots/import_roots_PY3_filelist.txt
+++ b/tests/package_import_roots/import_roots_PY3_filelist.txt
@@ -6,3 +6,4 @@ subpar/tests/__init__.py
 subpar/tests/package_import_roots/__init__.py
 subpar/tests/package_import_roots/import_roots
 subpar/tests/package_import_roots/import_roots.py
+UNPAR_MANIFEST

--- a/tests/package_pkg_resources/main_PY2_filelist.txt
+++ b/tests/package_pkg_resources/main_PY2_filelist.txt
@@ -17,3 +17,4 @@ subpar/tests/__init__.py
 subpar/tests/package_pkg_resources/__init__.py
 subpar/tests/package_pkg_resources/main
 subpar/tests/package_pkg_resources/main.py
+UNPAR_MANIFEST

--- a/tests/package_pkg_resources/main_PY3_filelist.txt
+++ b/tests/package_pkg_resources/main_PY3_filelist.txt
@@ -17,3 +17,4 @@ subpar/tests/__init__.py
 subpar/tests/package_pkg_resources/__init__.py
 subpar/tests/package_pkg_resources/main
 subpar/tests/package_pkg_resources/main.py
+UNPAR_MANIFEST

--- a/tests/package_shadow/main_PY2_filelist.txt
+++ b/tests/package_shadow/main_PY2_filelist.txt
@@ -8,3 +8,4 @@ subpar/tests/package_shadow/code/__init__.py
 subpar/tests/package_shadow/code/shadowed.py
 subpar/tests/package_shadow/main
 subpar/tests/package_shadow/main.py
+UNPAR_MANIFEST

--- a/tests/package_shadow/main_PY3_filelist.txt
+++ b/tests/package_shadow/main_PY3_filelist.txt
@@ -8,3 +8,4 @@ subpar/tests/package_shadow/code/__init__.py
 subpar/tests/package_shadow/code/shadowed.py
 subpar/tests/package_shadow/main
 subpar/tests/package_shadow/main.py
+UNPAR_MANIFEST


### PR DESCRIPTION
Co-authored: @ian-h-chamberlain

TLDR: Add `extract_dir` to `par_binary` which allows reuse of the
unpacked archive results.

When a `par_binary` is launched, if `zip_safe` is set to false, the zip
is unpacked to a temporary directory and deleted on exit.  We have run
into several issues because of this:

- There is an overhead, both CPU and user time, to unpack the zip each
    time that the application is launched.  If the `par_binary` is a
    CLI tool this overhead can be quite noticeable.  Especially if it's
    a tool that is supposed to be small, single function, script which is
    invoked frequently.

- The tempdir isn't cleaned up if the process recieves a KILL signal or
    the app exits uncleanly.  If using `systemd` a possible solution is to
    use `PrivateTmp=true` in the service unit file, which means that the
    entire `/tmp` directory is unique for the service and cleaned up by
    `systemd` when the application terminates (in any possible way.)

- No way to modify the archive on the fly.  This one is a questionable
    limitation as rebuilding and re-deploying the archive is a quick
    alternative.  We have explored whether a solution similar to
    https://superuser.com/questions/647674/is-there-a-way-to-edit-files-inside-of-a-zip-file-without-explicitly-extracting
    are possible.

The solution: Extract the archive to a static location, and re-use the
artifacts if the `par_binary` has not changed.

- Add a new `extract_dir` argument to the `par_binary` (and `par_test`,)
    macros.  This is a file path to where the the par archive will be
    unpacked to.  `extract_dir` is only applicable if `zip_safe == False`.

- **The `extract_dir` is not cleaned up on exit.**  If the archive has
    not changed then subsequent invocations will reuse the same unpacked
    results.  This saves the computational load of extracting the par each
    time that it's invoked.

- If the `extract_dir` cannot be written to then the application will
    fall back to writing to a temporary directory.

- If the `par_binary` changes the `extract_dir` will be removed and
    recreated.  **If the files within the `extract_dir` are modified the
    par won't be recreated.**

- Add a new runtime environment variable `UNPAR_EXTRACT_ONLY`. It
    launches the par, unpacks it to the `extract_dir`, and exits
    immediately.

**WARNING** Setting an `extract_dir` makes the `par_binary` unsafe to
invoke from multiple threads as the first invocation needs to unpack
into the `extract_dir`. To get around this invoke the application with
`UNPAR_EXTRACT_ONLY` during installation.