### PR TITLE
Add test cases for unpar

### DIFF
--- a/compiler/python_archive.py
+++ b/compiler/python_archive.py
@@ -312,11 +312,11 @@ class PythonArchive(object):
 
 
 def _update_hash(manifest_hash, resource):
-    local_filename = getattr(resource, "local_filename", None)
+    local_filename = getattr(resource, 'local_filename', None)
     if not local_filename:
         return
 
-    with open(local_filename, "rb") as f:
+    with open(local_filename, 'rb') as f:
         while True:
             chunk = f.read(8192)
             if not chunk:

--- a/compiler/python_archive.py
+++ b/compiler/python_archive.py
@@ -291,14 +291,17 @@ class PythonArchive(object):
             for relative_path, resource in items:
                 assert resource.zipinfo.filename == relative_path
                 resource.store(z)
-                _update_hash(manifest_hash, resource)
+                if self.extract_dir:
+                    _update_hash(manifest_hash, resource)
 
-            logging.debug(
-                "Hash calculated for manifest: %s", manifest_hash.hexdigest())
-            hash_file = stored_resource.StoredContent(
-                "UNPAR_MANIFEST", self.timestamp_tuple,
-                manifest_hash.hexdigest())
-            hash_file.store(z)
+            if self.extract_dir:
+                logging.debug(
+                    'Hash calculated for manifest: %s',
+                    manifest_hash.hexdigest())
+                hash_file = stored_resource.StoredContent(
+                    'PAR_MANIFEST', self.timestamp_tuple,
+                    manifest_hash.hexdigest())
+                hash_file.store(z)
 
     def create_final_from_temp(self, temp_parfile_name):
         """Move newly created parfile to its final filename."""

--- a/compiler/python_archive_test.py
+++ b/compiler/python_archive_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import os
 import shutil
 import subprocess
@@ -188,10 +187,10 @@ class PythonArchiveTest(unittest.TestCase):
         par2.create()
 
         # The two par files should be bit-for-bit identical
-        with contextlib.closing(open(par1.output_filename, 'rb')) as parfile:
+        with open(par1.output_filename, 'rb') as parfile:
             content1 = parfile.read()
 
-        with contextlib.closing(open(par2.output_filename, 'rb')) as parfile:
+        with open(par2.output_filename, 'rb') as parfile:
             content2 = parfile.read()
 
         self.assertEqual(content1, content2)
@@ -217,14 +216,14 @@ class PythonArchiveTest(unittest.TestCase):
             subprocess.check_output([par1.output_filename]),
             b'Hello World!\n')
 
-        with contextlib.closing(open(self._extracted_main, 'r')) as main:
+        with open(self._extracted_main, 'r') as main:
             self.assertIn('Hello World!', main.read())
 
         self.assertEqual(
             subprocess.check_output([par2.output_filename]),
             b'Hello World 2!\n')
 
-        with contextlib.closing(open(self._extracted_main, 'r')) as main:
+        with open(self._extracted_main, 'r') as main:
             self.assertIn('Hello World 2!', main.read())
 
     def test_create_temp_parfile(self):

--- a/compiler/python_archive_test.py
+++ b/compiler/python_archive_test.py
@@ -75,7 +75,8 @@ class PythonArchiveTest(unittest.TestCase):
 
     @property
     def _extracted_main(self):
-        return os.path.join(self.extract_dir, os.path.basename(self.main_file.name))
+        return os.path.join(self.extract_dir,
+                            os.path.basename(self.main_file.name))
 
     def test_create_manifest_not_found(self):
         par = self._construct(

--- a/runtime/support.py
+++ b/runtime/support.py
@@ -395,7 +395,8 @@ def setup(import_roots, zip_safe, extract_dir=None):
         import_prefix = extract_dir
     else:  # Import directly from .par file
         if extract_dir:
-            warnings.warn('extract_dir has no effect when zip_safe is True, ' +
+            warnings.warn(
+                'extract_dir has no effect when zip_safe is True, ' +
                 'but was still specified: %r' % extract_dir,
                 UserWarning)
         extract_dir = None

--- a/runtime/support.py
+++ b/runtime/support.py
@@ -121,39 +121,43 @@ def _extract_files(archive_path, extract_dir):
         else:
             extract_dir = _make_temporary_extract_dir()
 
-        _log('# extracting %r to %r' % (archive_path, extract_dir))
+        _log('# extracting %r to tmpdir: %r' % (archive_path, extract_dir))
         zip_file.extractall(extract_dir)
 
     return extract_dir
 
 
-def _get_manifest_path(directory=""):
-    return os.path.join(directory, "UNPAR_MANIFEST")
+def _get_manifest_path(directory=''):
+    return os.path.join(directory, 'PAR_MANIFEST')
 
 
 def _extract_to_known_location(archive_path, zip_file, extract_dir):
-    """Extract the contents of this .par to a user specified directory.
+    """
+    Extract the contents of this .par to a user specified directory.
 
     If the par has already been expanded to this same location nothing is done.
-      If the par has changed (or a different par points to the same
-    extract_dir,) the contents will be erased and re-written.
+    If the par has changed (or a different par points to the same extract_dir),
+    the contents will be erased and re-written.
+
+    If the given directory does not exist, it (and all parents) will be created
+    by `zipfile.ZipFile.extractall`
     """
     with contextlib.closing(
-            zip_file.open(_get_manifest_path(), "r")) as manifest:
+            zip_file.open(_get_manifest_path(), 'r')) as manifest:
         manifest_hash = manifest.read().decode()
 
     try:
-        with open(_get_manifest_path(extract_dir), "rb") as found_manifest:
+        with open(_get_manifest_path(extract_dir), 'rb') as found_manifest:
             found_hash = found_manifest.read().decode()
     except FileNotFoundError:
         pass
     else:
         if found_hash == manifest_hash:
-            _log("# existing hash matches, skipping extraction")
+            _log('# existing hash matches, skipping extraction')
             return
 
     shutil.rmtree(extract_dir, ignore_errors=True)
-    _log('# extracting %s to %s' % (archive_path, extract_dir))
+    _log('# extracting %r to %r' % (archive_path, extract_dir))
     zip_file.extractall(extract_dir)
 
 
@@ -365,10 +369,10 @@ def setup(import_roots, zip_safe, extract_dir=None):
 
     # Extract files to disk if necessary
     if not zip_safe:
-        extract_only = os.environ.get("UNPAR_EXTRACT_ONLY")
+        extract_only = os.environ.get('PAR_EXTRACT_ONLY')
         if extract_only:
             if not extract_dir:
-                sys.exit("UNPAR_EXTRACT_ONLY specified without an extract_dir")
+                sys.exit('PAR_EXTRACT_ONLY specified without an extract_dir')
             else:
                 shutil.rmtree(extract_dir, ignore_errors=True)
 
@@ -379,9 +383,9 @@ def setup(import_roots, zip_safe, extract_dir=None):
 
         if extract_only:
             if extract_dir != original_extract_dir:
-                sys.exit("unable to extract to %r" % original_extract_dir)
+                sys.exit('unable to extract to %r' % original_extract_dir)
 
-            sys.stderr.write("successfully unpacked par to %r\n" % extract_dir)
+            sys.stderr.write('successfully unpacked par to %r\n' % extract_dir)
             sys.exit(0)
 
         # sys.path[0] is the name of the executing .par file.  Point
@@ -390,6 +394,10 @@ def setup(import_roots, zip_safe, extract_dir=None):
         sys.path[0] = extract_dir
         import_prefix = extract_dir
     else:  # Import directly from .par file
+        if extract_dir:
+            warnings.warn('extract_dir has no effect when zip_safe is True, ' +
+                'but was still specified: %r' % extract_dir,
+                UserWarning)
         extract_dir = None
         import_prefix = archive_path
 

--- a/runtime/support_test.py
+++ b/runtime/support_test.py
@@ -59,7 +59,8 @@ class SupportTest(unittest.TestCase):
         cls.zipfile_name = zipfile_name
         cls.entry_name = entry_name
         cls.entry_data = entry_data
-        cls.extract_dir = os.path.join(tmpdir, '_support_test_sample_extract_dir')
+        cls.extract_dir = os.path.join(tmpdir,
+                                       '_support_test_sample_extract_dir')
 
         # Create mock loader object
         class MockLoader(object):

--- a/test_dir_shadowing/test_dir_shadowing_main_PY2_filelist.txt
+++ b/test_dir_shadowing/test_dir_shadowing_main_PY2_filelist.txt
@@ -9,4 +9,3 @@ subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib_dat.txt
 subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main.py
 subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main_dat.txt
 subpar/test_dir_shadowing/test_dir_shadowing_main
-UNPAR_MANIFEST

--- a/test_dir_shadowing/test_dir_shadowing_main_PY3_filelist.txt
+++ b/test_dir_shadowing/test_dir_shadowing_main_PY3_filelist.txt
@@ -9,4 +9,3 @@ subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_lib_dat.txt
 subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main.py
 subpar/test_dir_shadowing/test_dir_shadowing/dir_shadowing_main_dat.txt
 subpar/test_dir_shadowing/test_dir_shadowing_main
-UNPAR_MANIFEST

--- a/tests/package_a/a_PY2_filelist.txt
+++ b/tests/package_a/a_PY2_filelist.txt
@@ -7,4 +7,3 @@ subpar/tests/package_a/__init__.py
 subpar/tests/package_a/a
 subpar/tests/package_a/a.py
 subpar/tests/package_a/a_dat.txt
-UNPAR_MANIFEST

--- a/tests/package_a/a_PY3_filelist.txt
+++ b/tests/package_a/a_PY3_filelist.txt
@@ -7,4 +7,3 @@ subpar/tests/package_a/__init__.py
 subpar/tests/package_a/a
 subpar/tests/package_a/a.py
 subpar/tests/package_a/a_dat.txt
-UNPAR_MANIFEST

--- a/tests/package_b/b_PY2_filelist.txt
+++ b/tests/package_b/b_PY2_filelist.txt
@@ -13,4 +13,3 @@ subpar/tests/package_b/__init__.py
 subpar/tests/package_b/b
 subpar/tests/package_b/b.py
 subpar/tests/package_b/b_dat.txt
-UNPAR_MANIFEST

--- a/tests/package_b/b_PY3_filelist.txt
+++ b/tests/package_b/b_PY3_filelist.txt
@@ -13,4 +13,3 @@ subpar/tests/package_b/__init__.py
 subpar/tests/package_b/b
 subpar/tests/package_b/b.py
 subpar/tests/package_b/b_dat.txt
-UNPAR_MANIFEST

--- a/tests/package_boilerplate/main_PY2_filelist.txt
+++ b/tests/package_boilerplate/main_PY2_filelist.txt
@@ -6,4 +6,3 @@ subpar/tests/__init__.py
 subpar/tests/package_boilerplate/__init__.py
 subpar/tests/package_boilerplate/main
 subpar/tests/package_boilerplate/main.py
-UNPAR_MANIFEST

--- a/tests/package_boilerplate/main_PY3_filelist.txt
+++ b/tests/package_boilerplate/main_PY3_filelist.txt
@@ -6,4 +6,3 @@ subpar/tests/__init__.py
 subpar/tests/package_boilerplate/__init__.py
 subpar/tests/package_boilerplate/main
 subpar/tests/package_boilerplate/main.py
-UNPAR_MANIFEST

--- a/tests/package_c/c_PY2_filelist.txt
+++ b/tests/package_c/c_PY2_filelist.txt
@@ -16,4 +16,3 @@ subpar/tests/package_b/b_dat.txt
 subpar/tests/package_c/__init__.py
 subpar/tests/package_c/c
 subpar/tests/package_c/c.py
-UNPAR_MANIFEST

--- a/tests/package_c/c_PY3_filelist.txt
+++ b/tests/package_c/c_PY3_filelist.txt
@@ -16,4 +16,3 @@ subpar/tests/package_b/b_dat.txt
 subpar/tests/package_c/__init__.py
 subpar/tests/package_c/c
 subpar/tests/package_c/c.py
-UNPAR_MANIFEST

--- a/tests/package_d/d_PY2_filelist.txt
+++ b/tests/package_d/d_PY2_filelist.txt
@@ -19,4 +19,3 @@ subpar/tests/package_c/c.py
 subpar/tests/package_d/__init__.py
 subpar/tests/package_d/d
 subpar/tests/package_d/d.py
-UNPAR_MANIFEST

--- a/tests/package_d/d_PY3_filelist.txt
+++ b/tests/package_d/d_PY3_filelist.txt
@@ -19,4 +19,3 @@ subpar/tests/package_c/c.py
 subpar/tests/package_d/__init__.py
 subpar/tests/package_d/d
 subpar/tests/package_d/d.py
-UNPAR_MANIFEST

--- a/tests/package_e/e_PY2_filelist.txt
+++ b/tests/package_e/e_PY2_filelist.txt
@@ -11,4 +11,3 @@ test_workspace/__init__.py
 test_workspace/data_file.txt
 test_workspace/package_external_lib/__init__.py
 test_workspace/package_external_lib/external_lib.py
-UNPAR_MANIFEST

--- a/tests/package_e/e_PY3_filelist.txt
+++ b/tests/package_e/e_PY3_filelist.txt
@@ -11,4 +11,3 @@ test_workspace/__init__.py
 test_workspace/data_file.txt
 test_workspace/package_external_lib/__init__.py
 test_workspace/package_external_lib/external_lib.py
-UNPAR_MANIFEST

--- a/tests/package_extract/extract_PY2_filelist.txt
+++ b/tests/package_extract/extract_PY2_filelist.txt
@@ -9,4 +9,3 @@ subpar/tests/package_extract/extract.py
 subpar/tests/package_extract/extract_helper.py
 subpar/tests/package_extract/extract_helper_package/__init__.py
 subpar/tests/package_extract/extract_helper_package/extract_dat.txt
-UNPAR_MANIFEST

--- a/tests/package_extract/extract_PY3_filelist.txt
+++ b/tests/package_extract/extract_PY3_filelist.txt
@@ -9,4 +9,3 @@ subpar/tests/package_extract/extract.py
 subpar/tests/package_extract/extract_helper.py
 subpar/tests/package_extract/extract_helper_package/__init__.py
 subpar/tests/package_extract/extract_helper_package/extract_dat.txt
-UNPAR_MANIFEST

--- a/tests/package_f/f_PY2_filelist.txt
+++ b/tests/package_f/f_PY2_filelist.txt
@@ -6,4 +6,3 @@ subpar/tests/__init__.py
 subpar/tests/package_f/__init__.py
 subpar/tests/package_f/f
 subpar/tests/package_f/f_PY2.py
-UNPAR_MANIFEST

--- a/tests/package_f/f_PY3_filelist.txt
+++ b/tests/package_f/f_PY3_filelist.txt
@@ -6,4 +6,3 @@ subpar/tests/__init__.py
 subpar/tests/package_f/__init__.py
 subpar/tests/package_f/f
 subpar/tests/package_f/f_PY3.py
-UNPAR_MANIFEST

--- a/tests/package_import_roots/import_roots_PY2_filelist.txt
+++ b/tests/package_import_roots/import_roots_PY2_filelist.txt
@@ -6,4 +6,3 @@ subpar/tests/__init__.py
 subpar/tests/package_import_roots/__init__.py
 subpar/tests/package_import_roots/import_roots
 subpar/tests/package_import_roots/import_roots.py
-UNPAR_MANIFEST

--- a/tests/package_import_roots/import_roots_PY3_filelist.txt
+++ b/tests/package_import_roots/import_roots_PY3_filelist.txt
@@ -6,4 +6,3 @@ subpar/tests/__init__.py
 subpar/tests/package_import_roots/__init__.py
 subpar/tests/package_import_roots/import_roots
 subpar/tests/package_import_roots/import_roots.py
-UNPAR_MANIFEST

--- a/tests/package_pkg_resources/main_PY2_filelist.txt
+++ b/tests/package_pkg_resources/main_PY2_filelist.txt
@@ -17,4 +17,3 @@ subpar/tests/__init__.py
 subpar/tests/package_pkg_resources/__init__.py
 subpar/tests/package_pkg_resources/main
 subpar/tests/package_pkg_resources/main.py
-UNPAR_MANIFEST

--- a/tests/package_pkg_resources/main_PY3_filelist.txt
+++ b/tests/package_pkg_resources/main_PY3_filelist.txt
@@ -17,4 +17,3 @@ subpar/tests/__init__.py
 subpar/tests/package_pkg_resources/__init__.py
 subpar/tests/package_pkg_resources/main
 subpar/tests/package_pkg_resources/main.py
-UNPAR_MANIFEST

--- a/tests/package_shadow/main_PY2_filelist.txt
+++ b/tests/package_shadow/main_PY2_filelist.txt
@@ -8,4 +8,3 @@ subpar/tests/package_shadow/code/__init__.py
 subpar/tests/package_shadow/code/shadowed.py
 subpar/tests/package_shadow/main
 subpar/tests/package_shadow/main.py
-UNPAR_MANIFEST

--- a/tests/package_shadow/main_PY3_filelist.txt
+++ b/tests/package_shadow/main_PY3_filelist.txt
@@ -8,4 +8,3 @@ subpar/tests/package_shadow/code/__init__.py
 subpar/tests/package_shadow/code/shadowed.py
 subpar/tests/package_shadow/main
 subpar/tests/package_shadow/main.py
-UNPAR_MANIFEST


### PR DESCRIPTION
* Skip manifest hash when not using extract_dir 

* Verify that extraction to a specified directory works as expected, as well as
some error handling (e.g. destination not writable). Also test that different
inputs result in the output dir being overwritten and the par's output changes
accordingly. Also verify the payload main is not run when the PAR_EXTRACT_ONLY
environment variable is set.

* Fix some lint issues