### PR TITLE
Add PAR_EXTRACT_ROOT variable for custom dir

### DIFF
--- a/compiler/python_archive_test.py
+++ b/compiler/python_archive_test.py
@@ -135,6 +135,10 @@ class PythonArchiveTest(unittest.TestCase):
         self.assertTrue(os.path.exists(self._extracted_main))
 
     def test_create_extract_dir_fallback_to_tmp(self):
+        # Root can do anything, so this test doesn't work
+        if os.geteuid() ==0:
+            return
+
         self.zip_safe = False
         self.extract_dir = '/not_allowed'
 

--- a/compiler/python_archive_test.py
+++ b/compiler/python_archive_test.py
@@ -168,6 +168,32 @@ class PythonArchiveTest(unittest.TestCase):
 
         self.assertTrue(os.path.exists(self._extracted_main))
 
+    def test_extract_only_root_specified(self):
+        self.zip_safe = False
+        self.extract_dir = '/extract_out'
+
+        par = self._construct()
+        par.create()
+        self.assertTrue(os.path.exists(self.output_filename))
+
+        # The payload's main should not be run, and the subpar should be extracted
+        # under the specified root instead of the top-level /extract_out
+        self.assertEqual(
+            subprocess.check_output(
+                [self.output_filename],
+                env={
+                    'PAR_EXTRACT_ONLY': '1',
+                    'PAR_EXTRACT_ROOT': self.tmpdir,
+                }),
+            b'')
+
+        expected_extracted_main = os.path.join(
+            self.tmpdir,
+            'extract_out',
+            os.path.basename(self.main_file.name)
+        )
+        self.assertTrue(os.path.exists(expected_extracted_main))
+
     def test_create(self):
         par = self._construct()
         par.create()

--- a/compiler/python_archive_test.py
+++ b/compiler/python_archive_test.py
@@ -136,7 +136,7 @@ class PythonArchiveTest(unittest.TestCase):
 
     def test_create_extract_dir_fallback_to_tmp(self):
         # Root can do anything, so this test doesn't work
-        if os.geteuid() ==0:
+        if os.geteuid() == 0:
             return
 
         self.zip_safe = False

--- a/runtime/support.py
+++ b/runtime/support.py
@@ -376,7 +376,10 @@ def setup(import_roots, zip_safe, extract_dir=None):
             else:
                 shutil.rmtree(extract_dir, ignore_errors=True)
 
-            extract_dir = os.path.expanduser(extract_dir)
+            # Turn extract_dir into a relative path to join with the extraction root
+            extract_dir = os.path.expanduser(extract_dir).lstrip('/')
+            extraction_root = os.environ.get('PAR_EXTRACT_ROOT', '/')
+            extract_dir = os.path.join(extraction_root, extract_dir)
             original_extract_dir = extract_dir
 
         extract_dir = _extract_files(archive_path, extract_dir)

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 # Touch this to update all apt packages
 ENV REFRESHED_AT 2016-10-11:17:20:00
@@ -7,21 +7,17 @@ ENV REFRESHED_AT 2016-10-11:17:20:00
 RUN apt-get update -q && apt-get install -qy \
     apt-transport-https \
     curl \
+    git \
     python \
     python3 \
     software-properties-common
 
-# Java 8 for Bazel
-RUN add-apt-repository ppa:webupd8team/java
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true \
-    | /usr/bin/debconf-set-selections
-RUN apt-get update -q && apt-get install -qy \
-    oracle-java8-installer
+# JDK is no longer required since there is one bundled with Bazel
 
-# Bazel.  Instructions from https://www.bazel.io/versions/master/docs/install.html
+# Install Bazel.  Instructions from https://www.bazel.io/versions/master/docs/install.html
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" \
-    | sudo tee /etc/apt/sources.list.d/bazel.list \
+    | tee /etc/apt/sources.list.d/bazel.list \
     && curl https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg \
-    | sudo apt-key add -
+    | apt-key add -
 RUN apt-get update -q && apt-get install -qy \
     bazel


### PR DESCRIPTION
Allow users to specify `PAR_EXTRACT_ROOT` to unpar to a subdirectory there instead of `/`.

Update some unit tests accordingly, and fix some outdated stuff so we can actually run in Docker.

## Testing
```sh
./scripts/run_tests_in_docker.sh
```
Apparently CI is no longer enforced, so we should probably fix that.